### PR TITLE
Allow going to slide 0

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -45,7 +45,7 @@ module.exports = {
 						label: 'Verse No.',
 						id: 'number',
 						default: 1,
-						min: 1,
+						min: 0,
 						max: 999,
 					}
 				]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opensong",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software"
@@ -18,6 +18,7 @@
 		"url": "git+https://github.com/bitfocus/companion-module-opensong.git"
 	},
 	"author": "Noah Callaway <noah@thecallaways.net>",
+	"contributors": "Yuri Vidal <yu.ri.vidal@gmail.com>",
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/bitfocus/companion-module-opensong/issues"


### PR DESCRIPTION
This will allow the user to go to slide 0, in case they have manually created that slide number. 
We currently use Slide 0 to show the Copyright info of the song. This has been tested and works. Kept the default to 1 as most users will not be addressing slide 0 anyways.